### PR TITLE
pin external action to avoid supply chain attack

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,14 +69,14 @@ runs:
         echo "::endgroup::"
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
       with:
         python-version: '3.x'
     
     - name: Check ClaudeCode run history
       id: claudecode-history
       if: github.event_name == 'pull_request'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
       with:
         path: .claudecode-marker
         key: claudecode-${{ github.repository_id }}-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
@@ -149,14 +149,14 @@ runs:
     
     - name: Save ClaudeCode reservation to cache
       if: steps.claudecode-check.outputs.enable_claudecode == 'true' && github.event_name == 'pull_request'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
       with:
         path: .claudecode-marker
         key: claudecode-${{ github.repository_id }}-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
     
     - name: Set up Node.js
       if: steps.claudecode-check.outputs.enable_claudecode == 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
         node-version: '18'
     
@@ -307,7 +307,7 @@ runs:
     
     - name: Upload scan results
       if: always() && inputs.upload-results == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: security-review-results
         path: |


### PR DESCRIPTION
I pinned the external action references in claude-code-security-review from branches/tags to full commit SHAs.
This reduces the risk of supply chain attacks caused by tag replacement or branch updates.